### PR TITLE
Add regression test and initial docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,15 @@ y = model.full_fit_model(x, C=1.0, T_rot=2000, dx=0.0, w_inst=0.02, base=0.0, I_
 ```
 
 See `examples/01_quickstart.py`.
+
+## Documentation
+
+Project documentation is written in Markdown and built with [MkDocs](https://www.mkdocs.org/).
+To build the HTML site locally:
+
+```bash
+pip install mkdocs
+mkdocs build
+```
+
+The rendered site can be published automatically with GitHub Pages.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,42 @@
+# BH Spectra
+
+This project provides tools to model and fit the A–X band spectra of boron hydride (BH). It began life as a set of Jupyter notebooks and has since been refactored into a Python package.
+
+## Quick start
+
+Install the package in editable mode:
+
+```bash
+pip install -e .
+```
+
+Then run the command line tool:
+
+```bash
+bh-spectra --xmin 432.8 --xmax 434.2 --points 4000 --out spectrum.npz
+```
+
+Or use the Python API:
+
+```python
+import numpy as np
+from bh_spectra.dataio import load_v00_wavelengths
+from bh_spectra.physics import BHModel
+
+v00 = load_v00_wavelengths()
+model = BHModel(v00)
+x = np.linspace(432.8, 434.2, 4000)
+y = model.full_fit_model(x, C=1.0, T_rot=2000, dx=0.0, w_inst=0.02,
+                         base=0.0, I_R7=0.5, I_R8=0.3)
+```
+
+## Documentation
+
+These files are prepared for use with [MkDocs](https://www.mkdocs.org/). To build the site locally:
+
+```bash
+pip install mkdocs
+mkdocs build
+```
+
+The resulting HTML can be published with GitHub Pages.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,4 @@
+site_name: BH Spectra
+nav:
+  - Home: index.md
+docs_dir: docs

--- a/src/bh_spectra/dataio.py
+++ b/src/bh_spectra/dataio.py
@@ -3,13 +3,32 @@ import hashlib, json
 import numpy as np, pandas as pd
 from importlib import resources
 
+
+def n_air(wl_nm: float | np.ndarray) -> float | np.ndarray:
+    """Refractive index of air (Science Chronology / 理科年表 formula).
+
+    Parameters
+    ----------
+    wl_nm:
+        Wavelength in nanometers.
+
+    Returns
+    -------
+    float | np.ndarray
+        Refractive index of air at the given wavelength.
+    """
+    wl_um = np.asarray(wl_nm) * 1e-3  # convert to micrometers
+    tmp = 6432.8 + 2949810 / (146 - 1 / wl_um**2) + 25540 / (41 - 1 / wl_um**2)
+    return tmp * 1e-8 + 1
+
 def load_v00_wavelengths() -> pd.DataFrame:
     """Load 11BH_v00.csv from package resources and convert to wavelengths (nm)."""
     with resources.files("bh_spectra._resources").joinpath("11BH_v00.csv").open("rb") as f:
         v00_wn = pd.read_csv(f)  # expects columns P,Q,R in wavenumbers (cm^-1)
-    wl_nm = 1e7 / v00_wn  # vacuum nm
-    wl_nm.columns = ["P","Q","R"]
-    return wl_nm
+    wl_vac_nm = 1e7 / v00_wn  # vacuum wavelengths (nm)
+    wl_air_nm = wl_vac_nm / n_air(wl_vac_nm)  # convert to air wavelengths
+    wl_air_nm.columns = ["P", "Q", "R"]
+    return wl_air_nm
 
 def hash_params(d: dict) -> str:
     return hashlib.sha256(json.dumps(d, sort_keys=True, default=float).encode()).hexdigest()

--- a/tests/test_regression_original.py
+++ b/tests/test_regression_original.py
@@ -1,0 +1,46 @@
+import importlib.util
+import os
+import shutil
+from pathlib import Path
+
+import numpy as np
+
+from bh_spectra.dataio import load_v00_wavelengths
+from bh_spectra.physics import BHModel, Branch
+
+
+def load_original_module():
+    repo_root = Path(__file__).resolve().parents[1]
+    mod_path = repo_root / "examples" / "bh_spectrum.py"
+    spec = importlib.util.spec_from_file_location("bh_orig", mod_path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)  # type: ignore
+    return mod
+
+
+def test_new_matches_original(tmp_path):
+    orig = load_original_module()
+    # prepare resource CSV in temp dir as expected by original code
+    repo_root = Path(__file__).resolve().parents[1]
+    src_csv = repo_root / "src" / "bh_spectra" / "_resources" / "11BH_v00.csv"
+    dst_dir = tmp_path / "11BH_wl_Fernando"
+    dst_dir.mkdir()
+    shutil.copy(src_csv, dst_dir / "11BH_v00.csv")
+
+    x = np.linspace(432.8, 434.2, 1000)
+    params = dict(C=1.0, T_rot=2000, w_inst=0.02, T_tra=0.0, branch="Q")
+
+    # original spectrum
+    cwd = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        y_orig = orig.BH_spec(x, **params)
+    finally:
+        os.chdir(cwd)
+
+    # refactored spectrum
+    v00 = load_v00_wavelengths()
+    model = BHModel(v00)
+    y_new = model.spectrum(x, C=1.0, T_rot=2000, w_inst=0.02, T_tra=0.0, branch=Branch.Q)
+
+    assert np.allclose(y_new, y_orig, rtol=1e-6, atol=1e-10)


### PR DESCRIPTION
## Summary
- convert tabulated BH wavelengths to air values to match original notebook
- add regression test comparing refactored model against original script
- scaffold MkDocs-based documentation site

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pip install -e .` *(fails: Could not find a version that satisfies the requirement setuptools>=68)*
- `MPLBACKEND=Agg python examples/01_quickstart.py` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_689c0a911c58832a9e582ae049509e69