### PR TITLE
Add metadata headers to BH CSV resources and handle comments

### DIFF
--- a/examples/bh_spectrum.py
+++ b/examples/bh_spectrum.py
@@ -125,7 +125,7 @@ def BH_spec(x, C, T_rot, w_inst, T_tra, branch):
     int = 0
 
     # 0-0帯 波長 (Fernando, JMS (1991)) 0-0 band wavelengths
-    v00_wn = pd.read_csv(r"./11BH_wl_Fernando/11BH_v00.csv")
+    v00_wn = pd.read_csv(r"./11BH_wl_Fernando/11BH_v00.csv", comment="#")
     v00_wl = 1e7 / v00_wn / n_air(1e7 / v00_wn)
 
     for v in range(v_min, v_max + 1):

--- a/src/bh_spectra/_resources/11BH_v00.csv
+++ b/src/bh_spectra/_resources/11BH_v00.csv
@@ -1,3 +1,6 @@
+# P, Q, R - are the transition branches.
+# Units: wavenumbers in cm^-1.
+# Columns: P, Q, R = line-center wavenumbers; J = rotational quantum number.
 J,P,Q,R
 0,nan,nan,23097.81
 1,nan,23074.117,23121.849

--- a/src/bh_spectra/_resources/11BH_v11.csv
+++ b/src/bh_spectra/_resources/11BH_v11.csv
@@ -1,3 +1,6 @@
+# P, Q, R - are the transition branches.
+# Units: wavenumbers in cm^-1.
+# Columns: P, Q, R = line-center wavenumbers; J = rotational quantum number.
 J,P,Q,R
 0,nan,nan,22913.998
 1,nan,22891.132,22935.889

--- a/src/bh_spectra/_resources/11BH_v22.csv
+++ b/src/bh_spectra/_resources/11BH_v22.csv
@@ -1,3 +1,6 @@
+# P, Q, R - are the transition branches.
+# Units: wavenumbers in cm^-1.
+# Columns: P, Q, R = line-center wavenumbers; J = rotational quantum number.
 J,P,Q,R
 0,nan,nan,22569.666
 1,nan,22547.6,22588.612

--- a/src/bh_spectra/dataio.py
+++ b/src/bh_spectra/dataio.py
@@ -24,7 +24,9 @@ def n_air(wl_nm: float | np.ndarray) -> float | np.ndarray:
 def load_v00_wavelengths() -> pd.DataFrame:
     """Load 11BH_v00.csv from package resources and convert to wavelengths (nm)."""
     with resources.files("bh_spectra._resources").joinpath("11BH_v00.csv").open("rb") as f:
-        v00_wn = pd.read_csv(f)  # expects columns P,Q,R in wavenumbers (cm^-1)
+        v00_wn = pd.read_csv(
+            f, comment="#"
+        )  # expects columns P,Q,R in wavenumbers (cm^-1)
     wl_vac_nm = 1e7 / v00_wn  # vacuum wavelengths (nm)
     wl_air_nm = wl_vac_nm / n_air(wl_vac_nm)  # convert to air wavelengths
     wl_air_nm.columns = ["P", "Q", "R"]


### PR DESCRIPTION
## Summary
- add descriptive comment headers with branch info and units to BH transition CSVs
- update CSV loaders to skip commented headers
- adjust example spectrum script to read CSVs with comments

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_689c11bfa724832aae580f4e12d69652