### PR TITLE
docs: enable dark mode

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,6 +6,19 @@ theme:
     - navigation.instant
     - navigation.tracking
     - content.code.copy
+  palette:
+    - scheme: slate
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/weather-sunny
+        name: Switch to light mode
+    - scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/weather-night
+        name: Switch to dark mode
 plugins:
   - search
 markdown_extensions:


### PR DESCRIPTION
## Summary
- enable default dark mode for MkDocs material theme with toggle to light mode

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `mkdocs build` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d38d93038832ab1c3bca222b0a753