### PR TITLE
docs: adopt jupyter-like look and navigation

### DIFF
--- a/docs/stylesheets/jupyter.css
+++ b/docs/stylesheets/jupyter.css
@@ -1,0 +1,24 @@
+/* Custom Jupyter-style theme adjustments for Material MkDocs */
+:root {
+  --md-default-bg-color: #ffffff;
+  --md-default-fg-color: #000000;
+  --md-primary-fg-color: #0e55a0; /* Jupyter blue */
+  --md-accent-fg-color: #f37626;  /* Jupyter orange */
+}
+
+/* Sidebar background similar to Jupyter */
+.md-sidebar--primary {
+  background-color: #f5f5f5;
+}
+
+/* Highlight active navigation link */
+.md-nav--primary .md-nav__item--active > .md-nav__link {
+  color: var(--md-accent-fg-color);
+  font-weight: 600;
+}
+
+/* Match header with sidebar background */
+.md-header {
+  background-color: #f5f5f5;
+  color: #000;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,17 +5,20 @@ theme:
   features:
     - navigation.instant
     - navigation.tracking
+    - navigation.sections
+    - navigation.expand
+    - navigation.top
     - content.code.copy
   palette:
     - scheme: slate
-      primary: indigo
-      accent: indigo
+      primary: blue
+      accent: deep orange
       toggle:
         icon: material/weather-sunny
         name: Switch to light mode
     - scheme: default
-      primary: indigo
-      accent: indigo
+      primary: blue
+      accent: deep orange
       toggle:
         icon: material/weather-night
         name: Switch to dark mode
@@ -35,6 +38,8 @@ markdown_extensions:
   - pymdownx.critic
   - pymdownx.details
   - pymdownx.inlinehilite
+extra_css:
+  - stylesheets/jupyter.css
 extra_javascript:
   - javascripts/mathjax.js
   - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js


### PR DESCRIPTION
## Summary
- add custom CSS for Jupyter-inspired colors
- expand docs navigation and tweak palette

## Testing
- `pytest` *(fails: ValueError: Length mismatch: Expected axis has 4 elements, new values have 3 elements)*
- `mkdocs build`


------
https://chatgpt.com/codex/tasks/task_e_689d75c4a618832abba2cd58d90fbfc5